### PR TITLE
Added ref check before dbus_connection_unref. Fixes #17

### DIFF
--- a/src/modules/systemd/libzbxsystemd.c
+++ b/src/modules/systemd/libzbxsystemd.c
@@ -49,8 +49,9 @@ int zbx_module_init()
 }
 
 int zbx_module_uninit()
-{ 
-  dbus_connection_unref(conn);
+{
+  if (NULL != conn)
+    dbus_connection_unref(conn);
   return ZBX_MODULE_OK;
 }
 


### PR DESCRIPTION
In my opinion, dbus_connection_unref should just no-op when connection is NULL
without logging anything. Now, with this fix, it gets checked twice.