### PR TITLE
unref msg and free all mem we can closes #39

### DIFF
--- a/src/modules/systemd/cgroups.c
+++ b/src/modules/systemd/cgroups.c
@@ -58,6 +58,7 @@ int     cgroup_init()
                     zabbix_log(LOG_LEVEL_DEBUG, LOG_PREFIX "cpu_cgroup is cpuacct");
                 }
 
+                free(ddir);
                 pclose(fp);
                 return SYSINFO_RET_OK;
             }

--- a/src/modules/systemd/libzbxsystemd.c
+++ b/src/modules/systemd/libzbxsystemd.c
@@ -178,17 +178,20 @@ static int SYSTEMD_UNIT_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *result)
 
   if (NULL == (msg = dbus_exchange_message(msg))) {
     SET_MSG_RESULT(result, strdup("failed to list units"));
+    dbus_message_unref(msg);
     return res;
   }
 
   // check result message
   if (!dbus_message_iter_init(msg, &args)) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "no value returned");
+    dbus_message_unref(msg);
     return res;
   }
   
   if (DBUS_TYPE_ARRAY != dbus_message_iter_get_arg_type(&args)) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "returned value is not an array");
+    dbus_message_unref(msg);
     return res;
   }
   
@@ -420,17 +423,20 @@ static int SYSTEMD_SERVICE_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *resul
 
   if (NULL == (msg = dbus_exchange_message(msg))) {
     SET_MSG_RESULT(result, strdup("failed to list units"));
+    dbus_message_unref(msg);
     return res;
   }
 
   // check result message
   if (!dbus_message_iter_init(msg, &args)) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "no value returned");
+    dbus_message_unref(msg);
     return res;
   }
   
   if (DBUS_TYPE_ARRAY != dbus_message_iter_get_arg_type(&args)) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "returned value is not an array");
+    dbus_message_unref(msg);
     return res;
   }
   
@@ -446,6 +452,7 @@ static int SYSTEMD_SERVICE_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *resul
     dbus_message_iter_next_n(&unit, 6);
     if (DBUS_TYPE_INVALID == (type = dbus_message_iter_get_arg_type(&unit))) {
       zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "unexpected value type");
+      dbus_message_unref(msg);
       goto next_unit;
     }
 

--- a/src/modules/systemd/systemd.c
+++ b/src/modules/systemd/systemd.c
@@ -43,20 +43,26 @@ int systemd_get_unit(char *s, size_t n, const char* unit)
     "GetUnit");
   
   dbus_message_iter_init_append(msg, &args);
-  if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &c))
+  if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &c)){
+    dbus_message_unref(msg);
     return FAIL;
+  }
 
-  if (NULL == (msg = dbus_exchange_message(msg)))
+  if (NULL == (msg = dbus_exchange_message(msg))){
+    dbus_message_unref(msg);
     return FAIL;
+  }
 
   // read value
   if (!dbus_message_iter_init(msg, &args)) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "message has no arguments");
+    dbus_message_unref(msg);
     return FAIL;
   }
   
   if (DBUS_TYPE_OBJECT_PATH != (type = dbus_message_iter_get_arg_type(&args))) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "argument is not an object path: %c", type);
+    dbus_message_unref(msg);
     return FAIL;
   }
   


### PR DESCRIPTION
Closes #39 
Valgrind:
```
Dec 27 04:45:29 valgrind[7426]: --29770-- Discarding syms at 0xc7d4130-0xc7db481 in /usr/lib64/libnss_files-2.17.so (have_dinfo 1)
Dec 27 04:45:29 valgrind[7426]: ==29770==
Dec 27 04:45:29 valgrind[7426]: ==29770== HEAP SUMMARY:
Dec 27 04:45:29 valgrind[7426]: ==29770==     in use at exit: 137,558 bytes in 3,413 blocks
Dec 27 04:45:29 valgrind[7426]: ==29770==   total heap usage: 6,035,241 allocs, 6,031,828 frees, 512,020,631 bytes allocated
Dec 27 04:45:29 valgrind[7426]: ==29770==
Dec 27 04:45:29 valgrind[7426]: ==29770== Searching for pointers to 3,413 not-freed blocks
Dec 27 04:45:29 valgrind[7426]: ==29770== Checked 1,217,120 bytes
Dec 27 04:45:29 valgrind[7426]: ==29770==
Dec 27 04:45:29 valgrind[7426]: ==29770== LEAK SUMMARY:
Dec 27 04:45:29 valgrind[7426]: ==29770==    definitely lost: 0 bytes in 0 blocks
Dec 27 04:45:29 valgrind[7426]: ==29770==    indirectly lost: 0 bytes in 0 blocks
Dec 27 04:45:29 valgrind[7426]: ==29770==      possibly lost: 0 bytes in 0 blocks
Dec 27 04:45:29 valgrind[7426]: ==29770==    still reachable: 137,558 bytes in 3,413 blocks
Dec 27 04:45:29 valgrind[7426]: ==29770==         suppressed: 0 bytes in 0 blocks
Dec 27 04:45:29 valgrind[7426]: ==29770== Reachable blocks (those to which a pointer was found) are not shown.
Dec 27 04:45:29 valgrind[7426]: ==29770== To see them, rerun with: --leak-check=full --show-leak-kinds=all
Dec 27 04:45:29 valgrind[7426]: ==29770==
Dec 27 04:45:29 valgrind[7426]: ==29770== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Dec 27 04:45:29 valgrind[7426]: ==29770== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```