### PR TITLE
remove unnecessary unrefs to dbus message

### DIFF
--- a/src/modules/systemd/dbus.c
+++ b/src/modules/systemd/dbus.c
@@ -104,16 +104,13 @@ DBusMessage *dbus_exchange_message(DBusMessage *msg) {
   msg = dbus_pending_call_steal_reply(pending);
   if (NULL == msg) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "returned message is null");
-    dbus_message_unref(msg);
     return NULL;
   }
   dbus_pending_call_unref(pending);
 
   // check for errors
-  if (dbus_check_error(msg)){
-      dbus_message_unref(msg);
+  if (dbus_check_error(msg))
       return NULL;
-  }
 
   return msg;
 }

--- a/src/modules/systemd/libzbxsystemd.c
+++ b/src/modules/systemd/libzbxsystemd.c
@@ -178,7 +178,6 @@ static int SYSTEMD_UNIT_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *result)
 
   if (NULL == (msg = dbus_exchange_message(msg))) {
     SET_MSG_RESULT(result, strdup("failed to list units"));
-    dbus_message_unref(msg);
     return res;
   }
 
@@ -191,7 +190,6 @@ static int SYSTEMD_UNIT_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *result)
   
   if (DBUS_TYPE_ARRAY != dbus_message_iter_get_arg_type(&args)) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "returned value is not an array");
-    dbus_message_unref(msg);
     return res;
   }
   
@@ -423,20 +421,17 @@ static int SYSTEMD_SERVICE_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *resul
 
   if (NULL == (msg = dbus_exchange_message(msg))) {
     SET_MSG_RESULT(result, strdup("failed to list units"));
-    dbus_message_unref(msg);
     return res;
   }
 
   // check result message
   if (!dbus_message_iter_init(msg, &args)) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "no value returned");
-    dbus_message_unref(msg);
     return res;
   }
   
   if (DBUS_TYPE_ARRAY != dbus_message_iter_get_arg_type(&args)) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "returned value is not an array");
-    dbus_message_unref(msg);
     return res;
   }
   
@@ -452,7 +447,6 @@ static int SYSTEMD_SERVICE_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *resul
     dbus_message_iter_next_n(&unit, 6);
     if (DBUS_TYPE_INVALID == (type = dbus_message_iter_get_arg_type(&unit))) {
       zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "unexpected value type");
-      dbus_message_unref(msg);
       goto next_unit;
     }
 

--- a/src/modules/systemd/systemd.c
+++ b/src/modules/systemd/systemd.c
@@ -44,25 +44,21 @@ int systemd_get_unit(char *s, size_t n, const char* unit)
   
   dbus_message_iter_init_append(msg, &args);
   if (!dbus_message_iter_append_basic(&args, DBUS_TYPE_STRING, &c)){
-    dbus_message_unref(msg);
     return FAIL;
   }
 
   if (NULL == (msg = dbus_exchange_message(msg))){
-    dbus_message_unref(msg);
     return FAIL;
   }
 
   // read value
   if (!dbus_message_iter_init(msg, &args)) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "message has no arguments");
-    dbus_message_unref(msg);
     return FAIL;
   }
   
   if (DBUS_TYPE_OBJECT_PATH != (type = dbus_message_iter_get_arg_type(&args))) {
     zabbix_log(LOG_LEVEL_ERR, LOG_PREFIX "argument is not an object path: %c", type);
-    dbus_message_unref(msg);
     return FAIL;
   }
   


### PR DESCRIPTION
remove unnecessary unrefs to dbus message introduced in https://github.com/cavaliercoder/zabbix-module-systemd/commit/c6c2c26f2c995167ba2da0508de013bddcc73b19  because they break `systemd.service.info[]` key
this fix don't open memleak again just remove my excessive desire to free up memory.