### PR TITLE
Fix comparison between pointer and zero character constant.

### DIFF
--- a/src/modules/systemd/libzbxsystemd.c
+++ b/src/modules/systemd/libzbxsystemd.c
@@ -211,7 +211,7 @@ static int SYSTEMD_UNIT_DISCOVERY(AGENT_REQUEST *request, AGENT_RESULT *result)
       switch (i) {
       case 0:
         // filter by unit type
-        if(NULL != filter || '\0' != filter)
+        if(NULL != filter && '\0' != *filter)
           if(0 == systemd_cmptype(value.str, filter))
             goto next_unit;
 


### PR DESCRIPTION
Hi @cavaliercoder @jangaraj,

This fix #44

See,
```bash
libzbxsystemd.c: In function ‘SYSTEMD_UNIT_DISCOVERY’:
libzbxsystemd.c:214:35: warning: comparison between pointer and zero character constant [-Wpointer-compare]
  214 |         if(NULL != filter || '\0' != filter)
      |                                   ^~
libzbxsystemd.c:214:38: note: did you mean to dereference the pointer?
  214 |         if(NULL != filter || '\0' != filter)
      |
```
Signed-off-by: Mario Trangoni <mjtrangoni@gmail.com>